### PR TITLE
Opt-Out of Null Safety

### DIFF
--- a/functions/node/index.dart
+++ b/functions/node/index.dart
@@ -1,3 +1,4 @@
+// @dart=2.9
 import 'package:firebase_functions_interop/firebase_functions_interop.dart';
 
 void main() {


### PR DESCRIPTION
Add the dart version flag so build_runner doesn't try to compile it with null safety